### PR TITLE
Add best-practice guide template and restyle Azure DevOps guide

### DIFF
--- a/insights/azure-dev-ops-best-practices-guide.html
+++ b/insights/azure-dev-ops-best-practices-guide.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8" />
     <meta content="width=device-width,initial-scale=1.0,maximum-scale=1.0" name="viewport">
@@ -24,6 +23,35 @@
     <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:alt" content="Azure DevOps Best Practices | MAQ Software Insights">
     <meta property="og:locale" content="en_US">
+
+    <!-- Schema.org Markup -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "headline": "Azure DevOps Best Practice Guide",
+      "description": "Improve software delivery with our Azure DevOps Best Practice Guide. Learn how to plan sprints, implement CI/CD pipelines, integrate security, monitor performance, and prioritize quality in every release.",
+      "image": "https://maqsoftware.com/images/expertise/cloud-main.jpg",
+      "author": {
+        "@type": "Organization",
+        "name": "MAQ Software",
+        "url": "https://maqsoftware.com"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "MAQ Software",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://maqsoftware.com/images/logos/MAQ-Software-URL.png"
+        }
+      },
+      "dateModified": "2023-06-13",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://maqsoftware.com/insights/azure-dev-ops-best-practices-guide.html"
+      }
+    }
+    </script>
 
     <!-- Twitter Theme -->
     <meta name="twitter:widgets:theme" content="light">
@@ -57,12 +85,10 @@
     </script>
 </head>
 
-
 <body class="shop blog">
 
     <!-- Header -->
-    <header id="header" class="header header-absolute header-fixed-on-mobile header-transparent"
-        data-bkg-threshold="100" data-sticky-threshold="0"></header>
+    <header id="header" class="header header-absolute header-fixed-on-mobile header-transparent" data-bkg-threshold="100" data-sticky-threshold="0"></header>
     <!-- Header End -->
     <div class="section-block bkg-grey-ultralight"></div>
     <!-- Content -->
@@ -75,186 +101,78 @@
                         <div class="post-content with-background">
                             <h1 class="post-title center">Azure DevOps Best Practice Guide</h1>
 
-                            <div id="security">
+                            <p class="text-large mt-20">Azure DevOps brings together planning, development, delivery, and monitoring on a single platform. Used well, it shortens release cycles, improves software quality, and keeps teams aligned with customer needs.</p>
+                            <p class="text-large">Based on our delivery experience at MAQ Software, the practices below cover the full software development lifecycle—from sprint planning and CI/CD to security, monitoring, and architectural strategy.</p>
+
+                            <div id="planning-knowledge" class="mt-40">
+                                <h2>Planning & Knowledge</h2>
                                 <ol>
                                     <li class="text-xlarge"><strong>Plan sprints effectively</strong></li>
-                                    <br>
-                                    <p class="text-large">Define sprint goals, prioritize activities, estimate efforts,
-                                        track tasks, and create sprint backlogs in Azure DevOps. After each sprint, do a
-                                        sprint retrospective to analyze the activities done in the sprint. Plan for the
-                                        next sprint effectively based on the sprint backlogs. </p>
-                                    <li class="text-xlarge"><strong>Create a wiki</strong></li>
-                                    <br>
-                                    <p class="text-large">Creating a centralized knowledge base helps in improving
-                                        collaboration and communication between team members. Creating a wiki in ADO
-                                        also stores project architectures, personas, and knowledge base artifacts. Here
-                                        are some steps to take:
-                                    <ol>
-                                        <li class="text-large">Create deployment documents to guide team members on how
-                                            to build and deploy applications in the environments.</li>
-                                        <li class="text-large">Create SOP (Standard Operating Procedure) documents to
-                                            provide clarification on the accountability of team members on the tasks.
-                                        </li>
-                                    </ol>
-                                    </p>
-                                    <li class="text-xlarge"><strong>Implement Continuous Integration/Continuous Delivery
-                                            (CI/CD) </strong></li>
-                                    <br>
-                                    <p class="text-large">CI/CD is a key component of DevOps that emphasizes automation,
-                                        collaboration, and fast feedback. In general:
-                                    <ol>
-                                        <li class="text-large">Focus on continuous delivery by planning and setting up
-                                            policies to develop the code. </li>
-                                        <li class="text-large">Secure critical files by adding mandatory reviews for
-                                            each release. </li>
-                                        <li class="text-large"> Validate each build before sending it to the next stage.
-                                        </li>
-                                        <li class="text-large">Configure pipelines to run environment setup scripts as
-                                            part of the deployment process. </li>
-                                    </ol>
-                                    </p>
-                                    <p class="text-large"><b>Continuous integration</b> can be done through the building
-                                        and testing of new code, and the following steps:
-                                    <ol>
-                                        <li class="text-large">Create different task groups if multiple pipelines run
-                                            the same tasks. </li>
-                                        <li class="text-large">Automate quality checks that catch quality issues on the
-                                            dev servers. </li>
-                                    </ol>
-                                    </p>
-                                    <p class="text-large">Advancements in tools and cloud infrastructure have made
-                                        continuous integration easier than before. Through all this, customers benefit
-                                        from timely access to the latest release.</p>
-                                    <p class="text-large">Similarly, there are also steps that are taken for continuous
-                                        deployment:
-                                    <ol>
-                                        <li class="text-large">Deploy code changes to production automatically once they
-                                            have passed the necessary tests. This enables teams to release code faster
-                                            and more frequently. However, it also requires more robust testing and
-                                            monitoring processes to ensure that issues are caught and addressed quickly.
-                                        </li>
-                                        <li class="text-large">Store no secrets in the release pipeline.</li>
-                                        <li class="text-large">Upload required certificates and signing keys to secure
-                                            files.</li>
-                                        <li class="text-large">Identify post-deployment scenarios and run them after
-                                            deployment.</li>
-                                    </ol>
-                                    </p>
-                                    <p class="text-large">Links to setup CI/CD pipelines: </p>
-                                    <link><a class="text-large"
-                                        href="https://learn.microsoft.com/en-us/azure/devops/pipelines/apps/cd/azure/cicd-data-overview?view=azure-devops">Overview
-                                        of CI/CD data pipelines on Microsoft Azure - Azure Pipelines | Microsoft Learn
-                                    </a></link>
-                                    <br>
-                                    <a class="text-large"
-                                        href="https://learn.microsoft.com/en-us/azure/app-service/deploy-azure-pipelines?tabs=yaml">Configure
-                                        CI/CD with Azure Pipelines - Azure App Service | Microsoft Learn </a>
-                                    <br>
-                                    <br>
-                                    <li class="text-xlarge"><strong>Implement security practices continuously</strong>
-                                    </li>
-                                    <br>
-                                    <p class="text-large">Ensure continuous implementation of security practices in
-                                        DevOps by integrating security into every aspect of the software development
-                                        lifecycle. This should occur from planning, all the way to deployment and
-                                        maintenance.</p>
-                                    <p class="text-large">Incorporate security testing into the CI/CD pipeline. This
-                                        approach enables you to test and detect security vulnerabilities early in the
-                                        development process. You can identify potential security threats and risks by
-                                        conducting threat modeling at the beginning of projects.</p>
-                                    <p class="text-large">Secure Configuration Management (SCM) ensures that all
-                                        software and hardware configurations are secure and up to date. This includes
-                                        managing access controls, encryption keys, and other security-related settings.
-                                    </p>
-                                    <li class="text-xlarge"><strong>Monitor the right metrics continuously</strong></li>
-                                    <br>
-                                    <p class="text-large">Continuous monitoring is the key to ensuring that the software
-                                        is working as expected. You can continuously monitor the software's performance
-                                        and progress using burn-down and burn-up charts. These charts provide visual
-                                        representations of the work completed and the work remaining—enabling effective
-                                        tracking and monitoring.</p>
-                                    <p class="text-large">Setting up dashboards in Azure DevOps is another option. Use
-                                        the dashboards to track key project execution metrics, including capacity,
-                                        velocity, and other relevant indicators. </p>
-                                    <li class="text-xlarge"><strong>Focus on quality over quantity </strong>
-                                    </li>
-                                    <br>
-                                    <p class="text-large">Prioritizing quality over quantity is essential when
-                                        delivering software. To achieve this, teams must focus on building software that
-                                        meets or exceeds expected standards for functionality, usability, reliability,
-                                        and security.</p>
-                                    <p class="text-large">By emphasizing quality, teams ensure that the software
-                                        delivered is more reliable, secure, and user-friendly. They achieve this by:
-                                    <ul>
-                                        <li class="text-large">Implementing code review practices through pull requests.
-                                        </li>
-                                        <li class="text-large">Conducting thorough testing using well-defined test plans
-                                            and test suites. </li>
-                                        <li class="text-large">Identifying and addressing issues early in the
-                                            development process.</li>
-                                    </ul>
-                                    </p>
-                                    <br>
-                                    <p class="text-large">This approach minimizes the need for rework and enables faster
-                                        and more frequent releases, delivering exceptional software that builds customer
-                                        trust and loyalty while reducing the risk of errors, downtime, or security
-                                        breaches.</p>
-                                    <li class="text-xlarge"><strong>Focus on concepts first, and then on tools </strong>
-                                    </li>
-                                    <br>
-                                    <p class="text-large">In DevOps, selecting the right tool can improve the
-                                        collaboration and efficiency of the team. It helps them to build great software.
-                                        Follow these steps to optimize your process:
-                                    <ol>
-                                        <li class="text-large">Define your requirements first and do deep research on
-                                            available tools in the marketplace. </li>
-                                        <li class="text-large">Do the feasibility analysis of the tool based on your
-                                            requirements.</li>
-                                        <li class="text-large">Check how the tool can be integrated with other tools in
-                                            the project.</li>
-                                        <li class="text-large">Review all security and data protection features to avoid
-                                            any vulnerabilities.</li>
-                                        <li class="text-large">Assess the cost matrix to select the product with the
-                                            best value for money.</li>
-                                    </ol>
-                                    </p>
-                                    <p class="text-large">Repeatedly pursuing new tools will force the team to redo the
-                                        steps mentioned above. That would result in wasted cost, time, and effort. </p>
+                                    <p class="text-large">Define sprint goals, prioritize activities, estimate efforts, track tasks, and create sprint backlogs in Azure DevOps. After each sprint, run a retrospective to analyze what was delivered, then plan the next sprint based on the backlog.</p>
 
-                                    <li class="text-xlarge"><strong>Put the customer’s satisfaction first </strong></li>
-                                    <br>
-                                    <p class="text-large">Ensure customer preferences are prioritized throughout the
-                                        SDLC (Software Development Life Cycle). Begin by gathering customer requirements
-                                        and regularly seeking feedback from them. Doing this will help ensure alignment
-                                        and satisfaction from the customer throughout the development process.
-                                    </p>
-                                    <p class="text-large">Implement continuous delivery practices to provide value
-                                        frequently and focus on creating user-friendly software. Continuously collect
-                                        user feedback through surveys, customer interactions, and collaborative
-                                        workshops. You can utilize tools such as checklists and templates to streamline
-                                        the process. </p>
-                                    <li class="text-xlarge"><strong>Switch to microservices </strong></li>
-                                    <br>
-                                    <p class="text-large">Microservices are small services combined to make a larger
-                                        project. Switching to them will provide greater agility and scalability.
-                                        Identify the boundaries and plan for the architecture for a smooth delivery of
-                                        the project. </p>
+                                    <li class="text-xlarge"><strong>Create a wiki</strong></li>
+                                    <p class="text-large">A centralized knowledge base improves collaboration and communication between team members. Use the Azure DevOps wiki to store project architectures, personas, and knowledge-base artifacts. Include deployment documents that guide the team through builds and releases, and Standard Operating Procedure (SOP) documents that clarify accountability for recurring tasks.</p>
                                 </ol>
                             </div>
-                            <div class="row">
-                                <div class="column width-6">
-                                    <img src="/img/blog/BPG007-main.jpg" alt="">
-                                </div>
-                                <div class="column width-6">
-                                    <H2>Azure Databricks Best Practice Guide</H2>
-                                    <p class="text-large">Improve job speed and save storage with our 18 Azure
-                                        Databricks best practices</p>
-                                    <a href="/insights/azure-databricks-best-practices">Read More &rarr;</a><br>
-                                </div>
+
+                            <div id="cicd-security" class="mt-40">
+                                <h2>CI/CD & Security</h2>
+                                <ol start="3">
+                                    <li class="text-xlarge"><strong>Implement Continuous Integration / Continuous Delivery (CI/CD)</strong></li>
+                                    <p class="text-large">CI/CD is a key component of DevOps that emphasizes automation, collaboration, and fast feedback. Focus on continuous delivery by setting policies that govern how code is developed, secure critical files with mandatory reviews, validate every build before promoting it, and configure pipelines to run environment setup scripts as part of deployment.</p>
+                                    <p class="text-large"><strong>Continuous integration</strong> rests on automated builds and tests. Create shared task groups when multiple pipelines run the same tasks, and automate quality checks that catch issues on dev servers. Advancements in tooling and cloud infrastructure make this easier than ever, and customers benefit from timely access to the latest release.</p>
+                                    <p class="text-large"><strong>Continuous deployment</strong> takes that a step further: deploy code changes to production automatically once they pass the necessary tests, so teams can release faster and more frequently. This requires robust testing and monitoring to catch issues quickly. Store no secrets in the release pipeline, upload required certificates and signing keys to secure files, and identify post-deployment scenarios to run after every release.</p>
+                                    <p class="text-large">For pipeline setup details, see <a href="https://learn.microsoft.com/en-us/azure/devops/pipelines/apps/cd/azure/cicd-data-overview?view=azure-devops" target="_blank" rel="noopener noreferrer">Overview of CI/CD data pipelines on Microsoft Azure</a> and <a href="https://learn.microsoft.com/en-us/azure/app-service/deploy-azure-pipelines?tabs=yaml" target="_blank" rel="noopener noreferrer">Configure CI/CD with Azure Pipelines</a>.</p>
+
+                                    <li class="text-xlarge"><strong>Implement security practices continuously</strong></li>
+                                    <p class="text-large">Integrate security into every aspect of the software development lifecycle, from planning through deployment and maintenance. Build security testing into the CI/CD pipeline so vulnerabilities surface early, and conduct threat modeling at the start of projects to identify risks. Apply Secure Configuration Management (SCM) so that all software and hardware configurations stay secure and current, including access controls, encryption keys, and other security-related settings.</p>
+                                </ol>
                             </div>
-                            <div class="section-block pt-10 pb-10 bkg-white"></div>
-                            <div class="post-info center">
-                                <span class="post-date">Last updated: June 13, 2023</span>
+
+                            <div id="monitoring-quality" class="mt-40">
+                                <h2>Monitoring & Quality</h2>
+                                <ol start="5">
+                                    <li class="text-xlarge"><strong>Monitor the right metrics continuously</strong></li>
+                                    <p class="text-large">Continuous monitoring keeps the software working as expected. Track performance and progress with burn-down and burn-up charts, which visualize completed versus remaining work. Set up dashboards in Azure DevOps to track capacity, velocity, and other key project execution metrics.</p>
+
+                                    <li class="text-xlarge"><strong>Focus on quality over quantity</strong></li>
+                                    <p class="text-large">Prioritizing quality means building software that meets or exceeds expected standards for functionality, usability, reliability, and security. Implement code review through pull requests, conduct thorough testing using well-defined test plans and test suites, and identify issues early in the development process. This minimizes rework, enables faster releases, and reduces the risk of errors, downtime, or security breaches.</p>
+                                </ol>
+                            </div>
+
+                            <div id="strategy-architecture" class="mt-40">
+                                <h2>Strategy & Architecture</h2>
+                                <ol start="7">
+                                    <li class="text-xlarge"><strong>Focus on concepts first, and then on tools</strong></li>
+                                    <p class="text-large">The right tool improves collaboration and efficiency, but only if it fits the work. Define your requirements, research available options, run a feasibility analysis against those requirements, check how the tool integrates with the rest of your stack, review its security and data protection features, and assess the cost matrix for value. Repeatedly switching tools forces the team to redo this work and wastes cost, time, and effort.</p>
+
+                                    <li class="text-xlarge"><strong>Put the customer's satisfaction first</strong></li>
+                                    <p class="text-large">Prioritize customer preferences throughout the Software Development Life Cycle. Begin by gathering requirements and seek feedback at regular intervals to keep work aligned with what the customer needs. Implement continuous delivery so value reaches users frequently, and gather feedback through surveys, customer interactions, and collaborative workshops—using checklists and templates to streamline the process.</p>
+
+                                    <li class="text-xlarge"><strong>Switch to microservices</strong></li>
+                                    <p class="text-large">Microservices are small services combined to make a larger system. Adopting them brings greater agility and scalability. Identify service boundaries up front and plan the architecture deliberately to ensure smooth delivery.</p>
+                                </ol>
+                            </div>
+
+                            <hr class="mt-50 mb-20">
+                            <h3 class="mt-0 mb-20">References</h3>
+                            <ul class="defaultBody">
+                                <li class="text-large"><a href="https://learn.microsoft.com/en-us/azure/devops/pipelines/apps/cd/azure/cicd-data-overview?view=azure-devops" target="_blank" rel="noopener noreferrer">Overview of CI/CD data pipelines on Microsoft Azure</a> – Microsoft Corporation</li>
+                                <li class="text-large"><a href="https://learn.microsoft.com/en-us/azure/app-service/deploy-azure-pipelines?tabs=yaml" target="_blank" rel="noopener noreferrer">Configure CI/CD with Azure Pipelines</a> – Microsoft Corporation</li>
+                                <li class="text-large"><a href="https://learn.microsoft.com/en-us/azure/devops/boards/sprints/" target="_blank" rel="noopener noreferrer">Plan and track work with Azure Boards</a> – Microsoft Corporation</li>
+                                <li class="text-large"><a href="https://learn.microsoft.com/en-us/azure/devops/project/wiki/" target="_blank" rel="noopener noreferrer">About Azure DevOps wikis</a> – Microsoft Corporation</li>
+                            </ul>
+                            <hr class="mt-50 mb-20">
+                            <h3 class="mt-0 mb-20">Continue Reading</h3>
+                            <div class="row mb-40">
+                                <div class="column width-6">
+                                    <img src="/images/best-practices/BPG007-main.jpg" alt="Azure Databricks Best Practice Guide">
+                                </div>
+                                <div class="column width-5 offset-1">
+                                    <h3 class="mt-0 mb-10">Azure Databricks Best Practice Guide</h3>
+                                    <p class="text-large">Improve job speed and reduce storage costs with our Azure Databricks optimization best practices.</p>
+                                    <a class="text-large" href="/insights/azure-databricks-best-practices">Read the guide &rarr;</a>
+                                </div>
                             </div>
                         </div>
                     </article>
@@ -272,11 +190,7 @@
     <script src="/js/timber.master.min.js"></script>
     <script src="../js/sidenav.js"></script>
     <script>
-        // $("#header").load("/header");
-        // $("#footer").load("/footer");
-        // $("#header").load("/header.html");
-        $("#footer").load("/footer.html");
+$("#footer").load("/footer.html");
     </script>
 </body>
-
 </html>

--- a/template-elements/best-practice-guide-template.html
+++ b/template-elements/best-practice-guide-template.html
@@ -1,0 +1,181 @@
+<!--
+    BEST PRACTICE GUIDE — CANONICAL TEMPLATE
+    ----------------------------------------
+    Replace every [BRACKETED] placeholder. Do not introduce:
+      - IE9 conditional shims
+      - <link rel="canonical"> (unless explicitly needed)
+      - Twitter card meta tags
+      - duplicate title/description meta tags
+      - <br> spacers inside list items
+      - <b> tags (use <strong>)
+      - nested <ol>/<ul> inside <p>
+    Each best practice item = one <li class="text-xlarge"><strong>...</strong></li>
+    followed by exactly one <p class="text-large">...</p>.
+    Numbered items continue across sections via <ol start="N">.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta content="width=device-width,initial-scale=1.0,maximum-scale=1.0" name="viewport">
+
+    <!-- Page-Specific SEO Tags -->
+    <title>[GUIDE TITLE] | MAQ Software Insights</title>
+    <meta name="description" content="[150–160 char description summarizing the guide.]">
+    <meta name="keywords" content="[comma, separated, keywords, MAQ Software]">
+    <meta name="page-type" content="insight">
+    <meta name="page-topic" content="[GUIDE TITLE] | MAQ Software Insights">
+
+    <!-- Open Graph / Social -->
+    <meta property="og:title" content="[GUIDE TITLE] | MAQ Software Insights">
+    <meta property="og:description" content="[Same as meta description.]">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://maqsoftware.com/insights/[guide-slug].html">
+    <meta property="og:site_name" content="MAQ Software">
+    <meta property="og:image" content="/images/expertise/[image].jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/jpeg">
+    <meta property="og:image:alt" content="[GUIDE TITLE] | MAQ Software Insights">
+    <meta property="og:locale" content="en_US">
+
+    <!-- Schema.org Markup -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "headline": "[GUIDE TITLE]",
+      "description": "[Same as meta description.]",
+      "image": "https://maqsoftware.com/images/expertise/[image].jpg",
+      "author": {
+        "@type": "Organization",
+        "name": "MAQ Software",
+        "url": "https://maqsoftware.com"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "MAQ Software",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://maqsoftware.com/images/logos/MAQ-Software-URL.png"
+        }
+      },
+      "dateModified": "[YYYY-MM-DD]",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://maqsoftware.com/insights/[guide-slug].html"
+      }
+    }
+    </script>
+
+    <!-- Twitter Theme -->
+    <meta name="twitter:widgets:theme" content="light">
+
+    <!-- Favicon -->
+    <link rel="shortcut icon" type="image/x-icon" href="/images/logos/MAQ-Software-URL.png">
+
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CHind+Madurai:400,500&amp;subset=latin-ext" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+
+    <!-- CSS -->
+    <link rel="stylesheet" href="/css/core.min.css" />
+    <link rel="stylesheet" href="/css/skin.css" />
+    <link rel="stylesheet" href="/css/styles.css"/>
+
+    <!-- Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-S0W302CGQG"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-S0W302CGQG');
+    </script>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "oekduyvjws");
+    </script>
+</head>
+
+<body class="shop blog">
+
+    <!-- Header -->
+    <header id="header" class="header header-absolute header-fixed-on-mobile header-transparent" data-bkg-threshold="100" data-sticky-threshold="0"></header>
+    <!-- Header End -->
+    <div class="section-block bkg-grey-ultralight"></div>
+    <!-- Content -->
+    <div class="content clearfix best-practices-text">
+        <div class="section-block clearfix pt-0 pb-0 bkg-grey-ultralight">
+            <div class="row">
+                <!-- Content Inner -->
+                <div class="column width-10 offset-1 content-inner blog-single-post bkg-grey-ultralight">
+                    <article class="post">
+                        <div class="post-content with-background">
+                            <h1 class="post-title center">[GUIDE TITLE]</h1>
+
+                            <p class="text-large">[Intro paragraph: what the reader will learn and why it matters.]</p>
+                            <p class="text-large">[Optional second intro paragraph: MAQ Software experience or scope.]</p>
+
+                            <div id="[section-one-slug]">
+                                <h2>[Section One Heading]</h2>
+                                <ol>
+                                    <li class="text-xlarge"><strong>[Item 1 Title]</strong></li>
+                                    <p class="text-large">[Item 1 description. Use <strong>bold</strong> for emphasis and <code class="color-red bkg-grey-ultralight">code</code> for inline code.]</p>
+
+                                    <li class="text-xlarge"><strong>[Item 2 Title]</strong></li>
+                                    <p class="text-large">[Item 2 description.]</p>
+                                </ol>
+                            </div>
+
+                            <div id="[section-two-slug]">
+                                <h2>[Section Two Heading]</h2>
+                                <ol start="3">
+                                    <li class="text-xlarge"><strong>[Item 3 Title]</strong></li>
+                                    <p class="text-large">[Item 3 description.]</p>
+
+                                    <li class="text-xlarge"><strong>[Item 4 Title]</strong></li>
+                                    <p class="text-large">[Item 4 description.]</p>
+                                </ol>
+                            </div>
+
+                            <h2>References</h2>
+                            <ul class="defaultBody">
+                                <li class="text-large"><a href="[URL]" target="_blank" rel="noopener noreferrer">[Reference Title]</a> – [Source]</li>
+                                <li class="text-large"><a href="[URL]" target="_blank" rel="noopener noreferrer">[Reference Title]</a> – [Source]</li>
+                            </ul>
+
+                            <div class="row">
+                                <div class="column width-6">
+                                    <img src="/images/best-practices/[image].jpg" alt="">
+                                </div>
+                                <div class="column width-5 offset-1">
+                                    <p class="title-medium">Up Next</p><br><p class="title-small">[Next Guide Title]</p><br><a href="/insights/[next-guide-slug]">Learn More &rarr;</a><br>
+                                </div>
+                            </div>
+                            <div class="section-block pt-10 pb-10 bkg-white"></div>
+                            <div class="post-info center">
+                                <span class="post-date">Last updated: [Month DD, YYYY]</span>
+                            </div>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </div>
+        <div class="section-block bkg-grey-ultralight"></div>
+    </div>
+    <!-- Content End -->
+    <!-- Footer -->
+    <footer id="footer" class="footer footer-light bkg-grey-ultralight"></footer>
+    <!-- Footer End -->
+    <!-- Js -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="/js/timber.master.min.js"></script>
+    <script src="../js/sidenav.js"></script>
+    <script>
+$("#footer").load("/footer.html");
+    </script>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false
+}


### PR DESCRIPTION
## Summary
- Adds `template-elements/best-practice-guide-template.html` as the canonical scaffold for insights best-practice guides, codifying the head meta/OG/Schema.org structure, sectioning with `<div id>` + `<h2>` + numbered `<ol>`, list-item markup conventions, References block, and Continue Reading block.
- Rewrites `insights/azure-dev-ops-best-practices-guide.html` to conform: full SEO/OG/Schema.org head, intro paragraphs, four sectioned topic groups with `mt-40` spacing, valid list markup (no `<br>` spacers, `<strong>` over `<b>`, no nested `<ol>`/`<ul>` inside `<p>`), and References + Continue Reading sections separated by thin `<hr>` dividers with `<h3>` headings.
- Removes the "Last updated" timestamp from the Azure DevOps guide.

## Test plan
- [ ] Open `insights/azure-dev-ops-best-practices-guide.html` locally and confirm headings, section spacing, dividers, and Continue Reading card render correctly
- [ ] Verify the `/images/best-practices/BPG007-main.jpg` image resolves
- [ ] Confirm no console/HTML validation errors