### PR TITLE
Add JSON-LD structured data to index.html (issue #2044)

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,58 @@
   <script defer src="/js/step-image-card.js"></script>
   <script src="/js/customer-story-carousel-cards.js"></script>
 
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://www.maqsoftware.com/#organization",
+        "name": "MAQ Software",
+        "url": "https://www.maqsoftware.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://maqsoftware.com/images/logos/MAQ-Software-URL.png",
+          "width": 200,
+          "height": 60
+        },
+        "foundingDate": "2000",
+        "description": "Microsoft Fabric Featured Partner and Top 25 Global Microsoft Partner providing AI, data analytics, and cloud consulting services to Fortune 500 enterprises.",
+        "award": [
+          "Microsoft Fabric Featured Partner",
+          "Top 25 Global Microsoft Partner",
+          "2021 Microsoft Power BI Partner of the Year — Global Award Winner",
+          "Inc. 5000 — 12-time honoree"
+        ],
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "email": "CustomerSuccess@MAQSoftware.com",
+          "contactType": "customer service"
+        },
+        "sameAs": [
+          "https://twitter.com/MAQSoftware",
+          "https://www.linkedin.com/company/maq-software/",
+          "https://appsource.microsoft.com/en-us/marketplace/partner-dir/maqsoftware"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://www.maqsoftware.com/#website",
+        "url": "https://www.maqsoftware.com/",
+        "name": "MAQ Software",
+        "publisher": { "@id": "https://www.maqsoftware.com/#organization" },
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://www.maqsoftware.com/search?q={search_term_string}"
+          },
+          "query-input": "required name=search_term_string"
+        }
+      }
+    ]
+  }
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
Adds `Organization` and `WebSite` JSON-LD structured data to the `<head>` of `index.html` to improve search engine visibility and enable rich results. The schema includes MAQ Software's logo, founding date, description, awards, contact point, and social profile links, as well as a `SearchAction` for the website. Resolves #2044.